### PR TITLE
Handle comments and printing for jsx_unary_tag

### DIFF
--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1473,24 +1473,21 @@ and walk_expression expr t comments =
     let xs = exprs |> List.map (fun e -> Expression e) in
     walk_list xs t rest
   | Pexp_jsx_unary_element {jsx_unary_element_props = props} ->
-    let _ =
-      List.map
-        (fun prop ->
-          match prop with
-          | Parsetree.JSXPropPunning (_, _) -> ()
-          | Parsetree.JSXPropValue (_, _, expr) ->
-            let _leading, inside, trailing =
-              partition_by_loc comments expr.pexp_loc
-            in
-            let after_expr, _ =
-              partition_adjacent_trailing expr.pexp_loc trailing
-            in
-            attach t.trailing expr.pexp_loc after_expr;
-            walk_expression expr t inside
-          | Parsetree.JSXPropSpreading (_loc, _expr) -> ())
-        props
-    in
-    ()
+    List.iter
+      (fun prop ->
+        match prop with
+        | Parsetree.JSXPropPunning (_, _) -> ()
+        | Parsetree.JSXPropValue (_, _, expr) ->
+          let _leading, inside, trailing =
+            partition_by_loc comments expr.pexp_loc
+          in
+          let after_expr, _ =
+            partition_adjacent_trailing expr.pexp_loc trailing
+          in
+          attach t.trailing expr.pexp_loc after_expr;
+          walk_expression expr t inside
+        | Parsetree.JSXPropSpreading (_loc, _expr) -> ())
+      props
   | Pexp_jsx_container_element
       {
         jsx_container_element_opening_tag_end = opening_greater_than;

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1472,7 +1472,13 @@ and walk_expression expr t comments =
     in
     let xs = exprs |> List.map (fun e -> Expression e) in
     walk_list xs t rest
-  | Pexp_jsx_unary_element {jsx_unary_element_props = props} ->
+  | Pexp_jsx_unary_element
+      {jsx_unary_element_tag_name = tag; jsx_unary_element_props = props} ->
+    (* handles the comments at the tag *)
+    let _, _, trailing = partition_by_loc comments tag.loc in
+    let after_expr, _ = partition_adjacent_trailing tag.loc trailing in
+    attach t.trailing tag.loc after_expr;
+    (* handles the comments for the actual props *)
     List.iter
       (fun prop ->
         match prop with

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1473,21 +1473,16 @@ and walk_expression expr t comments =
     let xs = exprs |> List.map (fun e -> Expression e) in
     walk_list xs t rest
   | Pexp_jsx_unary_element {jsx_unary_element_props = props} ->
-      let xs = List.filter_map (fun prop -> 
+      let _ = List.map (fun prop -> 
       match prop with 
-      | Parsetree.JSXPropPunning (_, _) -> None
-      | Parsetree.JSXPropValue ({txt; loc}, _, expr) -> 
-          let () = print_endline txt in
-          let () = print_location loc |> Doc.to_string ~width:80 |> print_endline in
-          let () = print_location expr.pexp_loc|> Doc.to_string ~width:80 |> print_endline in
-          let () = log t in
-          let (_leading, _inside, trailing) = partition_by_loc comments expr.pexp_loc in
+      | Parsetree.JSXPropPunning (_, _) -> ()
+      | Parsetree.JSXPropValue (_, _, expr) -> 
+          let (_leading, inside, trailing) = partition_by_loc comments expr.pexp_loc in
           let after_expr, _ = partition_adjacent_trailing expr.pexp_loc trailing in
           attach t.trailing expr.pexp_loc after_expr;
-          Some (Expression expr)
-      | Parsetree.JSXPropSpreading (_loc, expr) -> Some (Expression expr)
-      ) props in
-      walk_list xs t []
+          walk_expression expr t inside;
+      | Parsetree.JSXPropSpreading (_loc, _expr) -> ()
+      ) props in ()
   | Pexp_jsx_container_element
       {
         jsx_container_element_opening_tag_end = opening_greater_than;

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1473,16 +1473,24 @@ and walk_expression expr t comments =
     let xs = exprs |> List.map (fun e -> Expression e) in
     walk_list xs t rest
   | Pexp_jsx_unary_element {jsx_unary_element_props = props} ->
-      let _ = List.map (fun prop -> 
-      match prop with 
-      | Parsetree.JSXPropPunning (_, _) -> ()
-      | Parsetree.JSXPropValue (_, _, expr) -> 
-          let (_leading, inside, trailing) = partition_by_loc comments expr.pexp_loc in
-          let after_expr, _ = partition_adjacent_trailing expr.pexp_loc trailing in
-          attach t.trailing expr.pexp_loc after_expr;
-          walk_expression expr t inside;
-      | Parsetree.JSXPropSpreading (_loc, _expr) -> ()
-      ) props in ()
+    let _ =
+      List.map
+        (fun prop ->
+          match prop with
+          | Parsetree.JSXPropPunning (_, _) -> ()
+          | Parsetree.JSXPropValue (_, _, expr) ->
+            let _leading, inside, trailing =
+              partition_by_loc comments expr.pexp_loc
+            in
+            let after_expr, _ =
+              partition_adjacent_trailing expr.pexp_loc trailing
+            in
+            attach t.trailing expr.pexp_loc after_expr;
+            walk_expression expr t inside
+          | Parsetree.JSXPropSpreading (_loc, _expr) -> ())
+        props
+    in
+    ()
   | Pexp_jsx_container_element
       {
         jsx_container_element_opening_tag_end = opening_greater_than;

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -24,7 +24,7 @@ let copy tbl =
 
 let empty = make ()
 
-let print_loc (k : Warnings.loc) =
+let print_location (k : Warnings.loc) =
   Doc.concat
     [
       Doc.lbracket;
@@ -41,7 +41,7 @@ let print_loc (k : Warnings.loc) =
 let print_entries tbl =
   Hashtbl.fold
     (fun (k : Location.t) (v : Comment.t list) acc ->
-      let loc = print_loc k in
+      let loc = print_location k in
       let doc =
         Doc.breakable_group ~force_break:true
           (Doc.concat
@@ -1472,9 +1472,22 @@ and walk_expression expr t comments =
     in
     let xs = exprs |> List.map (fun e -> Expression e) in
     walk_list xs t rest
-  | Pexp_jsx_unary_element _ ->
-    (* TODO: save me shulhi, not sure what needs to be done here *)
-    ()
+  | Pexp_jsx_unary_element {jsx_unary_element_props = props} ->
+      let xs = List.filter_map (fun prop -> 
+      match prop with 
+      | Parsetree.JSXPropPunning (_, _) -> None
+      | Parsetree.JSXPropValue ({txt; loc}, _, expr) -> 
+          let () = print_endline txt in
+          let () = print_location loc |> Doc.to_string ~width:80 |> print_endline in
+          let () = print_location expr.pexp_loc|> Doc.to_string ~width:80 |> print_endline in
+          let () = log t in
+          let (_leading, _inside, trailing) = partition_by_loc comments expr.pexp_loc in
+          let after_expr, _ = partition_adjacent_trailing expr.pexp_loc trailing in
+          attach t.trailing expr.pexp_loc after_expr;
+          Some (Expression expr)
+      | Parsetree.JSXPropSpreading (_loc, expr) -> Some (Expression expr)
+      ) props in
+      walk_list xs t []
   | Pexp_jsx_container_element
       {
         jsx_container_element_opening_tag_end = opening_greater_than;

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4312,42 +4312,44 @@ and print_pexp_apply ~state expr cmt_tbl =
 and print_jsx_unary_tag ~state tag_name props cmt_tbl =
   let name = print_jsx_name tag_name in
   let formatted_props = print_jsx_props ~state props cmt_tbl in
-  let has_no_props = List.is_empty props in
+  let tag_has_trailing_comment = has_trailing_comments cmt_tbl tag_name.loc in
+  let tag_has_no_props = List.is_empty props in
   let props_doc =
-    match props with
-    | [] -> Doc.nil
-    | _ ->
+    if tag_has_no_props then Doc.nil
+    else
       Doc.indent
         (Doc.concat
            [Doc.line; Doc.group (Doc.join formatted_props ~sep:Doc.line)])
   in
-  let tag_has_trailing_comment = has_trailing_comments cmt_tbl tag_name.loc in
   let opening_tag =
     print_comments
       (Doc.concat [Doc.less_than; name])
       cmt_tbl tag_name.Asttypes.loc
   in
-  let opening_tag =
-    if tag_has_trailing_comment && not has_no_props then Doc.indent opening_tag
+  let opening_tag_doc =
+    if tag_has_trailing_comment && not tag_has_no_props then
+      Doc.indent opening_tag
     else opening_tag
   in
-  let closing_tag =
-    if Doc.will_break props_doc then Doc.concat [Doc.soft_line; Doc.text "/>"]
-    else
-      Doc.concat
-        [
-          (if tag_has_trailing_comment && has_no_props then Doc.nil else Doc.line);
-          Doc.text "/>";
-        ]
+  let closing_tag_doc =
+    let sep =
+      match
+        (Doc.will_break props_doc, tag_has_trailing_comment, tag_has_no_props)
+      with
+      | true, _, _ -> Doc.soft_line
+      | false, true, true -> Doc.nil
+      | false, _, _ -> Doc.line
+    in
+    Doc.concat [sep; Doc.text "/>"]
   in
   Doc.group
     (Doc.concat
        [
-         opening_tag;
+         opening_tag_doc;
          props_doc;
-         (if tag_has_trailing_comment && has_no_props then Doc.hard_line
+         (if tag_has_trailing_comment && tag_has_no_props then Doc.hard_line
           else Doc.nil);
-         closing_tag;
+         closing_tag_doc;
        ])
 
 and print_jsx_container_tag ~state tag_name props

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4311,7 +4311,8 @@ and print_pexp_apply ~state expr cmt_tbl =
 
 and print_jsx_unary_tag ~state tag_name props cmt_tbl =
   let name = print_jsx_name tag_name in
-  let formatted_props = print_jsx_props ~state ~isUnary:true props cmt_tbl in
+  let formatted_props = print_jsx_props ~state props cmt_tbl in
+  let formatted_props = formatted_props @ [Doc.text "/>"] in
   Doc.group
    (Doc.concat
       [
@@ -4319,7 +4320,6 @@ and print_jsx_unary_tag ~state tag_name props cmt_tbl =
           (Doc.concat [Doc.less_than; name])
           cmt_tbl tag_name.Asttypes.loc;
         Doc.space;
-        (* todo: might not be needed if no props?*)
         Doc.indent (Doc.group (Doc.join formatted_props ~sep:Doc.line));
       ]);
 
@@ -4510,9 +4510,8 @@ and print_jsx_prop ~state prop cmt_tbl =
         Doc.rbrace;
       ]
 
-and print_jsx_props ~state ?(isUnary=false) props cmt_tbl : Doc.t list =
-  let props = props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl) in
-  if isUnary then props @ [Doc.text "/>"] else props
+and print_jsx_props ~state props cmt_tbl : Doc.t list =
+  props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl)
 
 
 (* div -> div.

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4312,7 +4312,6 @@ and print_pexp_apply ~state expr cmt_tbl =
 and print_jsx_unary_tag ~state tag_name props cmt_tbl =
   let name = print_jsx_name tag_name in
   let formatted_props = print_jsx_props ~state props cmt_tbl in
-  let formatted_props = formatted_props @ [Doc.text "/>"] in
   Doc.group
     (Doc.concat
        [
@@ -4322,6 +4321,8 @@ and print_jsx_unary_tag ~state tag_name props cmt_tbl =
          Doc.indent
            (Doc.concat
               [Doc.line; Doc.group (Doc.join formatted_props ~sep:Doc.line)]);
+         Doc.soft_line;
+         Doc.text "/>";
        ])
 
 and print_jsx_container_tag ~state tag_name props

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4314,14 +4314,15 @@ and print_jsx_unary_tag ~state tag_name props cmt_tbl =
   let formatted_props = print_jsx_props ~state props cmt_tbl in
   let formatted_props = formatted_props @ [Doc.text "/>"] in
   Doc.group
-   (Doc.concat
-      [
-        print_comments
-          (Doc.concat [Doc.less_than; name])
-          cmt_tbl tag_name.Asttypes.loc;
-        Doc.space;
-        Doc.indent (Doc.group (Doc.join formatted_props ~sep:Doc.line));
-      ]);
+    (Doc.concat
+       [
+         print_comments
+           (Doc.concat [Doc.less_than; name])
+           cmt_tbl tag_name.Asttypes.loc;
+         Doc.indent
+           (Doc.concat
+              [Doc.line; Doc.group (Doc.join formatted_props ~sep:Doc.line)]);
+       ])
 
 and print_jsx_container_tag ~state tag_name props
     (children : Parsetree.jsx_children) cmt_tbl =
@@ -4512,7 +4513,6 @@ and print_jsx_prop ~state prop cmt_tbl =
 
 and print_jsx_props ~state props cmt_tbl : Doc.t list =
   props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl)
-
 
 (* div -> div.
  * Navabar.createElement -> Navbar

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4311,23 +4311,17 @@ and print_pexp_apply ~state expr cmt_tbl =
 
 and print_jsx_unary_tag ~state tag_name props cmt_tbl =
   let name = print_jsx_name tag_name in
-  let formatted_props = print_jsx_props ~state props cmt_tbl in
+  let formatted_props = print_jsx_props ~state ~isUnary:true props cmt_tbl in
   Doc.group
-    (Doc.concat
-       [
-         Doc.group
-           (Doc.concat
-              [
-                print_comments
-                  (Doc.concat [Doc.less_than; name])
-                  cmt_tbl tag_name.Asttypes.loc;
-                Doc.space;
-                (* todo: might not be needed if no props?*)
-                Doc.join formatted_props ~sep:Doc.space;
-                Doc.text "/>";
-              ]);
-         Doc.nil;
-       ])
+   (Doc.concat
+      [
+        print_comments
+          (Doc.concat [Doc.less_than; name])
+          cmt_tbl tag_name.Asttypes.loc;
+        Doc.space;
+        (* todo: might not be needed if no props?*)
+        Doc.indent (Doc.group (Doc.join formatted_props ~sep:Doc.line));
+      ]);
 
 and print_jsx_container_tag ~state tag_name props
     (children : Parsetree.jsx_children) cmt_tbl =
@@ -4516,8 +4510,10 @@ and print_jsx_prop ~state prop cmt_tbl =
         Doc.rbrace;
       ]
 
-and print_jsx_props ~state props cmt_tbl : Doc.t list =
-  props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl)
+and print_jsx_props ~state ?(isUnary=false) props cmt_tbl : Doc.t list =
+  let props = props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl) in
+  if isUnary then props @ [Doc.text "/>"] else props
+
 
 (* div -> div.
  * Navabar.createElement -> Navbar

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4312,17 +4312,26 @@ and print_pexp_apply ~state expr cmt_tbl =
 and print_jsx_unary_tag ~state tag_name props cmt_tbl =
   let name = print_jsx_name tag_name in
   let formatted_props = print_jsx_props ~state props cmt_tbl in
+  let props_doc =
+    match props with
+    | [] -> Doc.nil
+    | _ ->
+      Doc.indent
+        (Doc.concat
+           [Doc.line; Doc.group (Doc.join formatted_props ~sep:Doc.line)])
+  in
+  let closing_tag =
+    if Doc.will_break props_doc then Doc.concat [Doc.soft_line; Doc.text "/>"]
+    else Doc.concat [Doc.space; Doc.text "/>"]
+  in
   Doc.group
     (Doc.concat
        [
          print_comments
            (Doc.concat [Doc.less_than; name])
            cmt_tbl tag_name.Asttypes.loc;
-         Doc.indent
-           (Doc.concat
-              [Doc.line; Doc.group (Doc.join formatted_props ~sep:Doc.line)]);
-         Doc.soft_line;
-         Doc.text "/>";
+         props_doc;
+         closing_tag;
        ])
 
 and print_jsx_container_tag ~state tag_name props


### PR DESCRIPTION
```rescript
// 1. Leading comment
<div /> // 1. Trailing comment

// 2. Leading comment
<div 
  // 2. Inside comment
  /> // 2. Trailing comment

// 3. Leading comment
<div id="hello" /> // 3. Trailing comment

// 4. Leading comment
<div 
// 4. Trailing comment 1
id="hello" 
 // 4. Trailing comment 2
  /> // 4. Trailing comment 3

// 5. Leading comment
<div id="hello" 
  // 5. Trailing comment 1
  prop1="a very long prop" // 5. Trailing comment 2
  prop2=a_very_long_prop_2 prop3=a_very_long_prop_3 prop3=a_very_long_prop prop4=a_very_long_prop_4 
  onClick={evt => {
    // 5. Inside comment 1
    f()
  }}/> // 5. Trailing comment 3

```

Formatted to,

```rescript
// 1. Leading comment
<div /> // 1. Trailing comment

// 2. Leading comment
<div
// 2. Inside comment
/> // 2. Trailing comment

// 3. Leading comment
<div id="hello" /> // 3. Trailing comment

// 4. Leading comment
<div
  // 4. Trailing comment 1
  id="hello"
  // 4. Trailing comment 2
/> // 4. Trailing comment 3

// 5. Leading comment
<div
  id="hello"
  // 5. Trailing comment 1
  prop1="a very long prop" // 5. Trailing comment 2
  prop2=a_very_long_prop_2
  prop3=a_very_long_prop_3
  prop3=a_very_long_prop
  prop4=a_very_long_prop_4
  onClick={evt => {
    // 5. Inside comment 1
    f()
  }}
/> // 5. Trailing comment 3

```

which should be the same as in the playground, https://rescript-lang.org/try?version=v11.1.4&module=esmodule&code=PTAEEYDpQGQUwIYBMCWA7A5qAxgewLb5xoAuAUADyoBuowAfHWFKACoBOCKANulnoWLkyIUACZo8ZHxwEipSjVBlQTcdACSaAM4okcWYIWqGaiW048ZA+cNEBmSYlSZDtxSlp6AvACIAFnDc3Li+dIwO0BxcvK42QmQiYAAsTtJxcglUnsqiqRYx1pmkEGQ+AUEhYSp5UZax-MUk4irhavnRVhlGzfaJogCsaS6NPR5eSH6BwaHKJmBDBV2jtqWqAA7suOvgfgig1HDsAJ6gIa6b22GDdYXdq2Ktl+ti3ggA+ocn7+cY78-vMSgZ72N6fI7HH64TD-Lbrd72YFw0EfL6Q36w7ZI7bJMFoqEwgHJOagaEAYV42AA1t4AN5wajNbyMWmteagRZaXT6NxCNaqUAAMwAFABKVoAXwlphuSwavJKfSAA

   