### PR TITLE
Handle comments and printing (part 2)

### DIFF
--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1473,6 +1473,11 @@ and walk_expression expr t comments =
     let xs = exprs |> List.map (fun e -> Expression e) in
     walk_list xs t rest
   | Pexp_jsx_unary_element
+      {jsx_unary_element_tag_name = tag; jsx_unary_element_props = []} ->
+    let _, _, trailing = partition_by_loc comments tag.loc in
+    let after_expr, _ = partition_adjacent_trailing tag.loc trailing in
+    attach t.trailing tag.loc after_expr
+  | Pexp_jsx_unary_element
       {jsx_unary_element_tag_name = tag; jsx_unary_element_props = props} ->
     let _leading, inside, trailing = partition_by_loc comments tag.loc in
     walk_list

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1484,11 +1484,14 @@ and walk_expression expr t comments =
       (props
       |> List.filter_map (fun prop ->
              match prop with
-             | Parsetree.JSXPropPunning (_, _) -> None
+             | Parsetree.JSXPropPunning (_, {loc}) ->
+               Some (ExprArgument {expr; loc})
              | Parsetree.JSXPropValue ({loc}, _, expr) ->
                let loc = {loc with loc_end = expr.pexp_loc.loc_end} in
                Some (ExprArgument {expr; loc})
-             | Parsetree.JSXPropSpreading (_, _) -> None))
+             | Parsetree.JSXPropSpreading (loc, expr) ->
+               let loc = {loc with loc_end = expr.pexp_loc.loc_end} in
+               Some (ExprArgument {expr; loc})))
       t trailing;
     walk_expression expr t inside
   | Pexp_jsx_container_element

--- a/compiler/syntax/src/res_comments_table.ml
+++ b/compiler/syntax/src/res_comments_table.ml
@@ -1482,7 +1482,10 @@ and walk_expression expr t comments =
     List.iter
       (fun prop ->
         match prop with
-        | Parsetree.JSXPropPunning (_, _) -> ()
+        | Parsetree.JSXPropPunning (_, {loc}) ->
+          let _leading, _inside, trailing = partition_by_loc comments loc in
+          let after_expr, _ = partition_adjacent_trailing loc trailing in
+          attach t.trailing loc after_expr
         | Parsetree.JSXPropValue (_, _, expr) ->
           let _leading, inside, trailing =
             partition_by_loc comments expr.pexp_loc

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4510,8 +4510,15 @@ and print_jsx_prop ~state prop cmt_tbl =
   let open Parsetree in
   match prop with
   | JSXPropPunning (is_optional, name) ->
-    if is_optional then Doc.concat [Doc.question; Doc.text name.txt]
-    else Doc.text name.txt
+    let prop_has_trailing_comment = has_trailing_comments cmt_tbl name.loc in
+    let () = CommentTable.print_location name.loc |> Doc.to_string ~width:80 |> print_endline in
+    let () = CommentTable.log cmt_tbl in
+    let doc =
+      if is_optional then Doc.concat [Doc.question; Doc.text name.txt]
+      else Doc.text name.txt
+    in
+    let doc = print_comments doc cmt_tbl name.loc in 
+    if prop_has_trailing_comment then Doc.group (Doc.concat [Doc.break_parent; doc]) else doc
   | JSXPropValue (name, is_optional, value) ->
     let value_doc =
       let v =

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4531,11 +4531,18 @@ and print_jsx_prop ~state prop cmt_tbl =
       match Parens.jsx_prop_expr value with
       | Parenthesized | Braced _ ->
         let inner_doc = if Parens.braced_expr value then add_parens v else v in
-        let doc = Doc.concat [Doc.lbrace; inner_doc; Doc.rbrace] in
-        Doc.concat [(if is_optional then Doc.question else Doc.nil); doc]
+        Doc.concat [Doc.lbrace; inner_doc; Doc.rbrace]
       | _ -> v
     in
-    let doc = Doc.concat [Doc.text name.txt; Doc.equal; Doc.group value_doc] in
+    let doc =
+      Doc.concat
+        [
+          Doc.text name.txt;
+          Doc.equal;
+          (if is_optional then Doc.question else Doc.nil);
+          Doc.group value_doc;
+        ]
+    in
     print_comments doc cmt_tbl value.pexp_loc
   | JSXPropSpreading (loc, value) ->
     let value =

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4547,7 +4547,6 @@ and print_jsx_prop ~state prop cmt_tbl =
       ]
 
 and print_jsx_props ~state props cmt_tbl : Doc.t list =
-  let () = CommentTable.log cmt_tbl in
   props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl)
 
 (* div -> div.

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4511,29 +4511,31 @@ and print_jsx_prop ~state prop cmt_tbl =
   match prop with
   | JSXPropPunning (is_optional, name) ->
     let prop_has_trailing_comment = has_trailing_comments cmt_tbl name.loc in
-    let () = CommentTable.print_location name.loc |> Doc.to_string ~width:80 |> print_endline in
+    let () =
+      CommentTable.print_location name.loc
+      |> Doc.to_string ~width:80 |> print_endline
+    in
     let () = CommentTable.log cmt_tbl in
     let doc =
       if is_optional then Doc.concat [Doc.question; Doc.text name.txt]
       else Doc.text name.txt
     in
-    let doc = print_comments doc cmt_tbl name.loc in 
-    if prop_has_trailing_comment then Doc.group (Doc.concat [Doc.break_parent; doc]) else doc
+    let doc = print_comments doc cmt_tbl name.loc in
+    if prop_has_trailing_comment then
+      Doc.group (Doc.concat [Doc.break_parent; doc])
+    else doc
   | JSXPropValue (name, is_optional, value) ->
     let value_doc =
-      let v =
-        Doc.concat
-          [
-            (if is_optional then Doc.question else Doc.nil);
-            print_expression_with_comments ~state value cmt_tbl;
-          ]
-      in
+      let v = print_expression_with_comments ~state value cmt_tbl in
       match Parens.jsx_prop_expr value with
       | Parenthesized | Braced _ ->
         let inner_doc = if Parens.braced_expr value then add_parens v else v in
-        if has_leading_line_comment cmt_tbl value.pexp_loc then
-          add_braces inner_doc
-        else Doc.concat [Doc.lbrace; inner_doc; Doc.rbrace]
+        let doc =
+          if has_leading_line_comment cmt_tbl value.pexp_loc then
+            add_braces inner_doc
+          else Doc.concat [Doc.lbrace; inner_doc; Doc.rbrace]
+        in
+        Doc.concat [(if is_optional then Doc.question else Doc.nil); doc]
       | _ -> v
     in
     Doc.concat [Doc.text name.txt; Doc.equal; Doc.group value_doc]

--- a/compiler/syntax/src/res_printer.ml
+++ b/compiler/syntax/src/res_printer.ml
@@ -4537,14 +4537,18 @@ and print_jsx_prop ~state prop cmt_tbl =
     in
     let doc = Doc.concat [Doc.text name.txt; Doc.equal; Doc.group value_doc] in
     print_comments doc cmt_tbl value.pexp_loc
-  | JSXPropSpreading (_, value) ->
-    Doc.concat
-      [
-        Doc.lbrace;
-        Doc.dotdotdot;
-        print_expression_with_comments ~state value cmt_tbl;
-        Doc.rbrace;
-      ]
+  | JSXPropSpreading (loc, value) ->
+    let value =
+      {value with pexp_loc = {value.pexp_loc with loc_start = loc.loc_start}}
+    in
+    Doc.group
+      (Doc.concat
+         [
+           Doc.lbrace;
+           Doc.dotdotdot;
+           print_expression_with_comments ~state value cmt_tbl;
+           Doc.rbrace;
+         ])
 
 and print_jsx_props ~state props cmt_tbl : Doc.t list =
   props |> List.map (fun prop -> print_jsx_prop ~state prop cmt_tbl)


### PR DESCRIPTION
Continuation of #3 

- Better approach to attaching comments which handled some other edge cases that I missed previously
- Handled the rest of missing implementation from previous PR (i.e. punning, props spread)

```rescript
<div 
// another
{...props} // props
  prop3=?{x} // prop3
  prop4=?x // prop 4
  prop5=?{() => // prop 5
    // inside
    f()
  } // prop 5
  />

<div {...props} // props
  prop3=?{x} // prop3
  prop4=x // prop 4
  prop5=?{() => // prop 5
    // inside
    f()
  } // prop 5
  />

// 1. Leading comment
<div /> // 1. Trailing comment

// 2. Leading comment
<div 
  // 2. Inside comment
  /> // 2. Trailing comment

// 3. Leading comment
<div id="hello" /> // 3. Trailing comment

// 4. Leading comment
<div 
// 4. Trailing comment 1
id="hello" 
 // 4. Trailing comment 2
  /> // 4. Trailing comment 3

// 5. Leading comment
<div id="hello" 
  // 5. Trailing comment 1
  prop1="a very long prop" // 5. Trailing comment 2
  prop2=a_very_long_prop_2 prop3=a_very_long_prop_3 prop3=a_very_long_prop prop4=a_very_long_prop_4 
  onClick={evt => {
    // 5. Inside comment 1
    f()
  }}/> // 5. Trailing comment 3
```

formatted to 

```rescript
<div
  {...// another
  props} // props
  prop3=?{x} // prop3
  prop4=?x // prop 4
  prop5=?{() =>
    // prop 5
    // inside
    f()}
  // prop 5
/>

<div
  {...props} // props
  prop3=?{x} // prop3
  prop4=x // prop 4
  prop5=?{() =>
    // prop 5
    // inside
    f()}
  // prop 5
/>

// 1. Leading comment
<div /> // 1. Trailing comment

// 2. Leading comment
<div
// 2. Inside comment
/> // 2. Trailing comment

// 3. Leading comment
<div id="hello" /> // 3. Trailing comment

// 4. Leading comment
<div
  // 4. Trailing comment 1
  id="hello"
  // 4. Trailing comment 2
/> // 4. Trailing comment 3

// 5. Leading comment
<div
  id="hello"
  // 5. Trailing comment 1
  prop1="a very long prop" // 5. Trailing comment 2
  prop2=a_very_long_prop_2
  prop3=a_very_long_prop_3
  prop3=a_very_long_prop
  prop4=a_very_long_prop_4
  onClick={evt => {
    // 5. Inside comment 1
    f()
  }}
/> // 5. Trailing comment 3
```

which are the same as in v11